### PR TITLE
change emacs backups to use directory; resolves #5

### DIFF
--- a/.emacs
+++ b/.emacs
@@ -113,3 +113,17 @@
 ;; Allow region downcase w/ C-x C-l
 (put 'downcase-region 'disabled nil)
 (put 'upcase-region 'disabled nil)
+
+;; Put backup files a little out of the way
+(defvar --backup-directory (concat user-emacs-directory "backups"))
+(if (not (file-exists-p --backup-directory))
+            (make-directory --backup-directory t))
+(setq backup-directory-alist `(("." . ,--backup-directory)))
+(setq make-backup-files t          ; backup file the first time it is saved
+      backup-by-copying t          ; don't clobber symlinks
+      version-control t            ; version numbers for backup files
+      delete-old-versions t        ; delete excess backup files silently
+      delete-by-moving-to-trash t  ; system recycle bin or whatever
+      auto-save-default t          ; auto-save every buffer that visits file
+      vc-make-backup-files t       ; backup version-controlled files too
+)

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .emacs.d/auto-save-list/
 .emacs.d/ac-comphist.dat
 .emacs.d/eshell/history
+.emacs.d./backups/


### PR DESCRIPTION
Even better than disabling is putting the backup files out of the way.
With help from:
http://stackoverflow.com/questions/151945/how-do-i-control-how-emacs-makes-backup-files
